### PR TITLE
make it possible to change the output mode through cli

### DIFF
--- a/eralchemy2/cst.py
+++ b/eralchemy2/cst.py
@@ -1,6 +1,7 @@
 """
 All the constants used in the module.
 """
+
 TABLE = (
     '"{}" [label=<<FONT FACE="Helvetica"><TABLE BORDER="0" CELLBORDER="1"'
     ' CELLPADDING="4" CELLSPACING="0">{}{}</TABLE></FONT>>];'

--- a/eralchemy2/helpers.py
+++ b/eralchemy2/helpers.py
@@ -16,8 +16,8 @@ def check_args(args: Namespace) -> None:
     check_args_has_attributes(args)
     if args.v:
         non_version_attrs = [v for k, v in args.__dict__.items() if k != "v"]
-        print("non_version_attrs", non_version_attrs)
         if len([v for v in non_version_attrs if v is not None]) != 0:
+            print("non_version_attrs", non_version_attrs)
             fail("Cannot show the version number with another command.")
         return
     if args.i is None:

--- a/eralchemy2/main.py
+++ b/eralchemy2/main.py
@@ -36,6 +36,7 @@ def cli() -> None:
     render_er(
         args.i,
         args.o,
+        args.m or "auto",
         include_tables=args.include_tables,
         include_columns=args.include_columns,
         exclude_tables=args.exclude_tables,
@@ -49,6 +50,11 @@ def get_argparser() -> argparse.ArgumentParser:
     parser.add_argument("-i", nargs="?", help="Database URI to process.")
     parser.add_argument("-o", nargs="?", help="Name of the file to write.")
     parser.add_argument("-s", nargs="?", help="Name of the schema.")
+    parser.add_argument(
+        "-m",
+        nargs="?",
+        help="Output mode to write format, default: auto",
+    )
     parser.add_argument(
         "--exclude-tables", "-x", nargs="+", help="Name of tables not to be displayed."
     )

--- a/eralchemy2/models.py
+++ b/eralchemy2/models.py
@@ -101,9 +101,11 @@ class Column(Drawable):
             key_opening="<u>" if self.is_key else "",
             key_closing="</u>" if self.is_key else "",
             col_name=FONT_TAGS.format(self.name),
-            type=FONT_TAGS.format(" [{}]").format(self.type)
-            if self.type is not None
-            else "",
+            type=(
+                FONT_TAGS.format(" [{}]").format(self.type)
+                if self.type is not None
+                else ""
+            ),
             null=" NOT NULL" if not self.is_null else "",
         )
 

--- a/tests/create_db.py
+++ b/tests/create_db.py
@@ -1,6 +1,7 @@
 """
 Script used to create an SQLite DB and test eralchemy2 in Homebrew.
 """
+
 import argparse
 
 


### PR DESCRIPTION
This makes it possible to add the output mode through the `-m` cli option.

Possible values are currently `auto` (determine by output file extension), `er`, `mermaid`, `graph` and `dot` - in the future, there will be `mermaid_er` added to fix #6