### PR TITLE
set right_cardinality for relationships with compound primary_keys

### DIFF
--- a/tests/test_sqla_multi_key.py
+++ b/tests/test_sqla_multi_key.py
@@ -1,0 +1,106 @@
+from sqlalchemy import Column, ForeignKey, String
+from sqlalchemy.orm import DeclarativeBase
+
+from eralchemy2.models import Relation, Table
+from eralchemy2.sqla import (
+    column_to_intermediary,
+    database_to_intermediary,
+    declarative_to_intermediary,
+    table_to_intermediary,
+)
+
+
+def test_columns_parent():
+    class Base(DeclarativeBase):
+        pass
+
+    class Parent(Base):
+        __tablename__ = "parent"
+        id = Column(String(), primary_key=True)
+
+    class Child(Base):
+        __tablename__ = "child"
+        id = Column(String(), primary_key=True)
+        parent = Column(String(), ForeignKey(Parent.id), primary_key=True)
+
+    tables, relationships = declarative_to_intermediary(Base)
+
+    assert len(tables) == 2
+    assert len(relationships) == 1
+    assert all(isinstance(t, Table) for t in tables)
+    assert all(isinstance(r, Relation) for r in relationships)
+    relation = relationships[0]
+    assert relation.right_cardinality == "*"
+    assert relation.left_cardinality == "1"
+
+
+def test_columns_one_to_many_parent():
+    class Base(DeclarativeBase):
+        pass
+
+    class Parent(Base):
+        __tablename__ = "parent"
+        id = Column(String(), primary_key=True)
+
+    class Child(Base):
+        __tablename__ = "child"
+        id = Column(String(), primary_key=True)
+        parent = Column(String(), ForeignKey(Parent.id))
+
+    tables, relationships = declarative_to_intermediary(Base)
+
+    assert len(tables) == 2
+    assert len(relationships) == 1
+    assert all(isinstance(t, Table) for t in tables)
+    assert all(isinstance(r, Relation) for r in relationships)
+    relation = relationships[0]
+    assert relation.right_cardinality == "*"
+    assert relation.left_cardinality == "?"
+
+
+def test_columns_one_to_one_parent():
+    class Base(DeclarativeBase):
+        pass
+
+    class Parent(Base):
+        __tablename__ = "parent"
+        id = Column(String(), primary_key=True)
+
+    class Child(Base):
+        __tablename__ = "child"
+        id = Column(String(), ForeignKey(Parent.id), primary_key=True)
+
+    tables, relationships = declarative_to_intermediary(Base)
+
+    assert len(tables) == 2
+    assert len(relationships) == 1
+    assert all(isinstance(t, Table) for t in tables)
+    assert all(isinstance(r, Relation) for r in relationships)
+    relation = relationships[0]
+    assert relation.right_cardinality == "1"
+    assert relation.left_cardinality == "1"
+
+
+def test_compound_one_to_one_parent():
+    class Base(DeclarativeBase):
+        pass
+
+    class Parent(Base):
+        __tablename__ = "parent"
+        id = Column(String(), primary_key=True)
+        id2 = Column(String(), primary_key=True)
+
+    class Child(Base):
+        __tablename__ = "child"
+        id = Column(String(), ForeignKey(Parent.id), primary_key=True)
+        id2 = Column(String(), ForeignKey(Parent.id2), primary_key=True)
+
+    tables, relationships = declarative_to_intermediary(Base)
+
+    assert len(tables) == 2
+    assert len(relationships) == 2
+    assert all(isinstance(t, Table) for t in tables)
+    assert all(isinstance(r, Relation) for r in relationships)
+    for relation in relationships:
+        assert relation.right_cardinality == "1"
+        assert relation.left_cardinality == "1"


### PR DESCRIPTION
The cardinality was 1 when a compound primary key is a foreign key when it therefore should be 0..N - as the other primary key can change too, rendering the possibility to have multiple entries with the same primary column a - as long as primary column b changes.

An example of this can be seen in the `newsmeme.py` example or in #21 .

This fixes the behavior introduced in #15 to match compound keys.

This also sets the correct value, if all primary_keys of one table are the foreign keys of all primary_keys of another table - rendering a compound 1 to 1 relationship.

Additional tests are added to make sure the intended behavior is reached.

