### PR TITLE
Add possibility to retrieve information from multiple schemas at once

### DIFF
--- a/eralchemy2/sqla.py
+++ b/eralchemy2/sqla.py
@@ -126,11 +126,20 @@ def database_to_intermediary(
     Base = automap_base()
     engine = create_engine(database_uri)
     if schema is not None:
-        Base.metadata.schema = schema
+        schemas = schema.split(",")
+        for schema in schemas:
+            schema = schema.strip()
+            # reflect the tables
+            Base.metadata.schema = schema
+            Base.prepare(
+                engine,
+                name_for_scalar_relationship=name_for_scalar_relationship,
+            )
+    else:
+        # reflect the tables
+        Base.prepare(
+            engine,
+            name_for_scalar_relationship=name_for_scalar_relationship,
+        )
 
-    # reflect the tables
-    Base.prepare(
-        engine,
-        name_for_scalar_relationship=name_for_scalar_relationship,
-    )
     return declarative_to_intermediary(Base)

--- a/tests/test_sqla_to_intermediary.py
+++ b/tests/test_sqla_to_intermediary.py
@@ -80,6 +80,21 @@ def test_database_to_intermediary_with_schema():
     assert exclude_relation not in relationships
 
 
+def test_database_to_intermediary_with_multiple_schemas():
+    db_uri = create_db()
+    tables, relationships = database_to_intermediary(
+        db_uri, schema="public, eralchemy_test"
+    )
+
+    assert len(tables) == 6
+    assert len(relationships) == 4
+    assert all(isinstance(t, Table) for t in tables)
+    assert all(isinstance(r, Relation) for r in relationships)
+    # Not in because different schema.
+    assert relation not in relationships
+    assert exclude_relation not in relationships
+
+
 def test_flask_sqlalchemy():
     from flask import Flask
     from flask_sqlalchemy import SQLAlchemy


### PR DESCRIPTION
To retrieve information from multiple schemas, one has to prepare the base accordingly

A list of schemas can be used by setting a comma-separated string (as it is the case for the postgresql search path).
This should fix #18 