### PR TITLE
mark test parameter as raw string

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -61,7 +61,7 @@ def test_filter_no_include_no_exclude():
     "include_tables",
     (
         ["parent", "child", "excl"],
-        ["^(?!exc)\w+$"],  # all not starting with excl
+        [r"^(?!exc)\w+$"],  # all not starting with excl
         ["parent", "child"],
         ["parent", "^ch.*"],
         ["par.*", "child"],


### PR DESCRIPTION
Thanks for this project!

The new test marker (and notice about same on https://github.com/conda-forge/eralchemy2-feedstock/issues/3)  is helpful.

Of note, I do see:

```
tests/test_main.py:64
  $SRC_DIR/src/tests/test_main.py:64: SyntaxWarning: invalid escape sequence '\w'
    ["^(?!exc)\w+$"],  # all not starting with excl
```

This single-character PR marks it as a raw string, which should squash that warning