### PR TITLE
Improve-README-add-python-examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ from eralchemy2 import render_er
 ## Draw from SQLAlchemy base
 render_er(Base, 'erd_from_sqlalchemy.png')
 
+## Or draw from SQLAlchemy metadata
+metadata = mapper_registry.metadata
+render_er(metadata, 'erd_from_sqlalchemy.png')
+
+## You can also generate Mermaid ER and render it easily in markdown
+render_er(metadata, "mermaid_erd.md", mode="mermaid_er")
+
 ## Draw from database
 render_er("sqlite:///relative/path/to/db.db", 'erd_from_sqlite.png')
 ```


### PR DESCRIPTION
Hello 👋 

The fact that you can generate graph from SQLAlchemy metadata object is not advertised in the README so I added an example for that (and the mermaid markdown diagram)

Also FYI it seems like `.mermaid` files are rendered directly by github/gitlab so I'm not sure the whole mermaid in markdown format is needed ?


Thanks for reviving this library 🙂 